### PR TITLE
ci: parallel lint/typecheck/test/build workflow and PR lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run TypeScript check
+        run: npm run typecheck
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npx vitest run --reporter=dot --silent
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, unit-tests]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        # Run the build directly (not `npm run build`, whose script prefixes
+        # `npm i --silent`) to avoid a redundant install after `npm ci`.
+        run: |
+          npx vite build -l error
+          cp dist/index.html dist/404.html

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,72 @@
+name: PR Lint
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-lint:
+    name: Title and body
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title and body
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -u
+
+          # Bots open PRs without test plans — skip with success (exit 0 inside
+          # the step, not a job-level `if:`, so the check still reports
+          # "success" rather than "skipped" and can be required).
+          if [ "$GITHUB_ACTOR" = 'dependabot[bot]' ] || [ "$GITHUB_ACTOR" = 'github-actions[bot]' ]; then
+            echo "Skipping PR lint for bot actor: $GITHUB_ACTOR"
+            exit 0
+          fi
+
+          fail=0
+
+          # 1. Title must use conventional-commit style, optional (scope):
+          #      feat: ... | feat(shop): ... | fix: ... | chore: ... etc.
+          title_regex='^(feat|fix|perf|refactor|chore|ci|docs|deps|test|build|style)(\([a-z0-9-]+\))?: .+'
+          if ! echo "$PR_TITLE" | grep -Eq "$title_regex"; then
+            echo "::error::PR title must start with a conventional-commit prefix (optional scope):"
+            echo "::error::  feat: ...  feat(shop): ...  fix: ...  perf: ...  refactor: ..."
+            echo "::error::  chore: ... ci: ...  docs: ...  deps: ...  test: ...  build: ...  style: ..."
+            echo "::error::Got: '$PR_TITLE'"
+            fail=1
+          fi
+
+          # 2. Body must not be empty and must be a meaningful length
+          body_len=$(echo -n "${PR_BODY:-}" | wc -c)
+          if [ "$body_len" -lt 40 ]; then
+            echo "::error::PR body is missing or too short (<40 chars). Describe what changed and why."
+            fail=1
+          fi
+
+          # 3. Body must include a Test plan section with real content
+          if ! echo "$PR_BODY" | grep -Eq '^## Test plan'; then
+            echo "::error::PR body must include a '## Test plan' section."
+            echo "::error::Provide step-by-step tester actions, or 'N/A — <reason>' for pure refactor/docs/ci/deps."
+            fail=1
+          else
+            tp_content=$(echo "$PR_BODY" | awk '
+              /^## Test plan/ {intp=1; next}
+              /^## / {intp=0}
+              intp {print}
+            ' | perl -0pe 's/<!--.*?-->//gs' | tr -d '[:space:]')
+            if [ -z "$tp_content" ]; then
+              echo "::error::'## Test plan' section is empty or only contains the template comment."
+              echo "::error::Add steps or 'N/A — <reason>'."
+              fail=1
+            fi
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "PR lint passed."

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "npm i --silent && vite",
     "build": "npm i --silent && vite build -l error && cp dist/index.html dist/404.html && echo 'Project built successfully!'",
     "test": "npm i --silent && tsc --noEmit && eslint && vitest run --reporter=dot --silent && vite build -l error && cp dist/index.html dist/404.html && echo 'All tests passed!'",
-    "deploy": "npm run build && npx -y nostr-deploy-cli deploy --skip-setup"
+    "deploy": "npm run build && npx -y nostr-deploy-cli deploy --skip-setup",
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.6",


### PR DESCRIPTION
## Summary

Ports robotechy's CI depth as its own PR: `ci.yml` runs Lint, Type Check and Unit Tests as parallel jobs gating a Build job (all installing with `npm ci`), and `pr-lint.yml` enforces conventional-commit PR titles (scopes allowed) and a non-empty `## Test plan` section, skipping bot authors. Adds the `lint`/`typecheck` npm scripts the jobs call.

## Test plan

- N/A for unit tests — workflow-only change; the workflows themselves run on this PR (CI + PR Lint checks should appear below and pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)