### PR TITLE
ci: black-panther deploy pipeline, Dockerfile and dependabot

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+# Public identifiers baked into the production build (safe to commit).
+VITE_EDEN_PUBKEY=ccf86076887e10849ea52004da467c79947768b0b68c209940ae65ea0cebe095
+VITE_STALL_ID=ic5HtZ7CBy7JZPPFs36Kas

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/deploy-trigger.yml
+++ b/.github/workflows/deploy-trigger.yml
@@ -1,0 +1,49 @@
+name: Trigger production deploy
+
+# Production edenweeks.art runs as a Docker container in the `apps-stack` on
+# the self-hosted `black-panther` box. On a `v*` tag this fires a
+# repository_dispatch to the private BenGWeeks/black-panther repo, whose
+# self-hosted runner rebuilds & restarts the container.
+#
+# Required secret:
+#   BLACK_PANTHER_DEPLOY_TOKEN — a token with access to BenGWeeks/black-panther
+#   able to POST repository dispatches.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag/branch/sha to deploy (defaults to the run ref)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch deploy to black-panther
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire deploy-edenweeks
+        env:
+          TOKEN: ${{ secrets.BLACK_PANTHER_DEPLOY_TOKEN }}
+          REF: ${{ github.event.inputs.ref || github.ref_name }}
+        run: |
+          if [ -z "${TOKEN}" ]; then
+            echo "::error::BLACK_PANTHER_DEPLOY_TOKEN is not set — cannot trigger the deploy."
+            exit 1
+          fi
+          PAYLOAD=$(jq -nc --arg ref "$REF" \
+            '{event_type:"deploy-edenweeks",client_payload:{ref:$ref}}')
+          curl -fsS -X POST \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/BenGWeeks/black-panther/dispatches \
+            -d "$PAYLOAD"
+          echo "Dispatched deploy-edenweeks for ${REF}."

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ yarn.lock
 .env.*
 !.env.example
 !.env.test
+!.env.production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,22 @@
-FROM node:20-alpine AS builder
+# Build stage
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
 COPY package*.json ./
-
-# Install dependencies
 RUN npm ci
 
-# Copy source files
 COPY . .
+# Vite bakes VITE_* values from .env.production (public identifiers only)
+RUN npx vite build -l error && cp dist/index.html dist/404.html
 
-# Build the app
-RUN npm run build
+# Production stage — static hosting, matching robotechy's serve setup
+FROM node:22-alpine
 
-# Production stage - serve with nginx
-FROM nginx:alpine
+WORKDIR /app
+RUN npm install -g serve
 
-# Copy built files to nginx
-COPY --from=builder /app/dist /usr/share/nginx/html
-
-# Copy nginx config for SPA routing
-RUN echo 'server { \
-    listen 80; \
-    root /usr/share/nginx/html; \
-    index index.html; \
-    location / { \
-        try_files $uri $uri/ /index.html; \
-    } \
-}' > /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist ./dist
 
 EXPOSE 80
-
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["serve", "-s", "dist", "-l", "80"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN npx vite build -l error && cp dist/index.html dist/404.html
 FROM node:22-alpine
 
 WORKDIR /app
-RUN npm install -g serve
+RUN npm install -g serve@14.2.6
 
 COPY --from=builder /app/dist ./dist
 


### PR DESCRIPTION
## Summary

Replicates robotechy's deployment pipeline for Eden's site:

- **Dockerfile** — Vite production build served statically with `serve` on port 80, matching the existing `eden-weeks-art` container's port mapping (8082:80) on black-panther. `.env.production` commits the two public build-time identifiers (pubkey + stall id).
- **deploy-trigger.yml** — pushing a `v*` tag fires a `deploy-edenweeks` repository_dispatch to `BenGWeeks/black-panther`, whose self-hosted runner rebuilds and restarts the container (companion PR in that repo).
- **dependabot.yml** — weekly grouped npm version updates and monthly GitHub Actions updates.

**Setup needed by an admin (can't be done with my token):**
1. Add the `BLACK_PANTHER_DEPLOY_TOKEN` secret to this repo (same PAT robotechy-website uses).
2. Enable Dependabot alerts + security updates in Settings → Advanced Security (the API returned 404 for my token; `dependabot.yml` covers version updates but alerts are a repo setting).

## Test plan

- `npm run test` — all green
- Docker build not run locally (no docker CLI on this dev box); the Dockerfile is byte-for-byte robotechy's proven pattern minus the order-service, and the first black-panther deploy run will exercise it

🤖 Generated with [Claude Code](https://claude.com/claude-code)