### PR TITLE
ci: dependabot ignore rules for pinned and blocked dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,21 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # Manually managed exact pins: @nostrify/react and @nostrify/nostrify
+      # must move together (0.x minors are breaking; mismatches nest a second
+      # incompatible copy — see PR #14). Upgrade deliberately, not via bot.
+      - dependency-name: "@nostrify/*"
+      # Blocked majors — remove each entry once the blocker clears:
+      # eslint 10: @html-eslint/eslint-plugin peers on eslint <=9
+      - dependency-name: eslint
+        update-types: ["version-update:semver-major"]
+      # date-fns 4: react-day-picker 8.x peers on date-fns ^2 || ^3
+      - dependency-name: date-fns
+        update-types: ["version-update:semver-major"]
+      # @unhead/addons 3.x pulls a second unhead incompatible with @unhead/react 2.x
+      - dependency-name: "@unhead/*"
+        update-types: ["version-update:semver-major"]
     groups:
       minor-and-patch:
         update-types: [minor, patch]


### PR DESCRIPTION
## Summary

Dependabot's first sweep opened five PRs; four fail CI for structural reasons this config encodes:

- **`@nostrify/*` excluded from bot updates entirely** — the exact pins (react 0.2.31 / nostrify 0.50.5) must move together; the grouped PR (#25) bumped react to 0.6.3 (a breaking 0.x "minor") and broke NoteContent rendering. These get upgraded deliberately.
- **Majors ignored, each documented with its blocker**: eslint 10 (`@html-eslint/eslint-plugin` peers on ≤9 — #26), date-fns 4 (`react-day-picker` peers on ^2||^3 — #28), `@unhead/*` (addons 3.x pulls a second incompatible `unhead` — #29). Remove each entry when its blocker clears.

After merging, comment `@dependabot recreate` on #25 to get a clean grouped PR without nostrify; Dependabot will close #26/#28/#29 itself on its next run. #27 (Alby SDK) is green and mergeable as-is.

## Test plan

- N/A — dependabot config only; validated against the documented schema