### PR TITLE
fix: redirect plain-http production traffic to https

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,18 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
+// Plain-http pages are insecure contexts, where the browser disables
+// crypto.randomUUID — which the Nostr stack needs to open relay
+// subscriptions — so every query silently dies and the whole site looks
+// empty. Bounce production traffic to https before the app boots.
+// (localhost and LAN IPs stay untouched for development.)
+if (
+  window.location.protocol === 'http:' &&
+  window.location.hostname.endsWith('edenweeks.art')
+) {
+  window.location.replace(window.location.href.replace(/^http:/, 'https:'));
+}
+
 // Import polyfills first
 import './lib/polyfills.ts';
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,8 +7,10 @@ import { createRoot } from 'react-dom/client';
 // empty. Bounce production traffic to https before the app boots.
 // (localhost and LAN IPs stay untouched for development.)
 if (
+  import.meta.env.PROD &&
   window.location.protocol === 'http:' &&
-  window.location.hostname.endsWith('edenweeks.art')
+  (window.location.hostname === 'edenweeks.art' ||
+    window.location.hostname.endsWith('.edenweeks.art'))
 ) {
   window.location.replace(window.location.href.replace(/^http:/, 'https:'));
 }


### PR DESCRIPTION
## Summary

Root cause of every "site is empty" report: `http://edenweeks.art` is an insecure origin, where browsers disable `crypto.randomUUID` — which nostrify uses to create relay subscription ids. Relay sockets open but no REQ is ever sent, so the shop/banner/story/gallery all render empty with no console errors. `https://` works perfectly (94 gallery tiles).

This adds a tiny pre-boot guard in `main.tsx`: production hostnames on `http:` bounce to `https:` before the app initialises. localhost and LAN IPs are untouched for development.

**Also flip "Force SSL" for the edenweeks.art host in Nginx Proxy Manager on black-panther** — the proxy-level 301 is the proper fix (this PR is defence in depth, and covers any future proxy misconfiguration).

## Test plan

- `npm run test` — green
- Dev server on localhost/LAN confirmed unaffected (hostname guard)
- After deploy: `curl -sI http://edenweeks.art/gallery` still 200s from the proxy, but the page self-redirects; verify gallery populates on the http URL end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)