### PR TITLE
fix: exchange-rate unmount guard + relay publish-timeout noise

### DIFF
--- a/order-service/lib/relayErrors.js
+++ b/order-service/lib/relayErrors.js
@@ -27,6 +27,14 @@ const RELAY_NOISE = [
   // specific to ws's upgrade path — the LNURL/Lightning fetch path can never
   // produce it — so matching it cannot swallow a real payment error.
   'unexpected server response',
+  // nostr-tools' relay publish timeout ("publish timed out"), raised on an
+  // internal promise nobody awaits when a slow relay never ACKs the event.
+  // The publish paths already handle per-relay failures via allSettled — a
+  // single slow relay must not kill the service (crashed production on
+  // 2026-07-02 and restarted the container via the supervised entrypoint).
+  // Phrase is specific to the relay publish path, so it cannot swallow a
+  // Lightning/LNURL HTTP timeout.
+  'publish timed out',
   // Specific connection/socket phrases only — a bare 'connection' or 'timeout'
   // would swallow unrelated failures (e.g. a Lightning/LNURL HTTP timeout, which
   // is a real error). Relay/socket timeouts reaching this handler always carry a

--- a/order-service/test/relayErrors.test.js
+++ b/order-service/test/relayErrors.test.js
@@ -18,6 +18,15 @@ test('ignores the ws handshake rejection ("Unexpected server response: 403") tha
   assert.equal(isIgnorableRelayError(new Error('Unexpected server response: 502')), true);
 });
 
+test('ignores the relay publish timeout ("publish timed out") that crashed the service in production', () => {
+  // nostr-tools raises this on an internal promise when a slow relay never
+  // ACKs a published event — relay noise, not a genuine bug (2026-07-02).
+  assert.equal(isIgnorableRelayError(new Error('publish timed out')), true);
+  // But generic/HTTP timeouts must STAY fatal (LNURL fetch timeouts are real).
+  assert.equal(isIgnorableRelayError(new Error('Request Timeout')), false);
+  assert.equal(isIgnorableRelayError(new Error('fetch timeout')), false);
+});
+
 test('ignores known transient relay/network errors (case-insensitive)', () => {
   for (const m of [
     'restricted: Pay on https://nostr.land for access.',

--- a/src/hooks/useExchangeRate.ts
+++ b/src/hooks/useExchangeRate.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { getExchangeRates } from '@/lib/exchangeRate';
 
 interface UseExchangeRateReturn {
@@ -23,28 +23,39 @@ export function useExchangeRate(): UseExchangeRateReturn {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Tracks whether the component is still mounted, so the async rate fetch never
+  // calls setState after unmount — which otherwise surfaces as an unhandled
+  // "window is not defined" from React's scheduler once a test env tears down.
+  const mountedRef = useRef(false);
+
   const fetchRates = useCallback(async () => {
     setIsLoading(true);
     setError(null);
 
     try {
       const rates = await getExchangeRates();
+      if (!mountedRef.current) return;
       // sats per £1 = 100,000,000 / BTC price in GBP
       setSatsPerGbp(Math.round(SATS_PER_BTC / rates.btcToGbp));
       setSatsPerUsd(Math.round(SATS_PER_BTC / rates.btcToUsd));
     } catch (err) {
+      if (!mountedRef.current) return;
       const message = err instanceof Error ? err.message : 'Failed to fetch rates';
       setError(message);
       // Use fallback rates
       setSatsPerGbp(Math.round(SATS_PER_BTC / FALLBACK_BTC_GBP));
       setSatsPerUsd(Math.round(SATS_PER_BTC / FALLBACK_BTC_USD));
     } finally {
-      setIsLoading(false);
+      if (mountedRef.current) setIsLoading(false);
     }
   }, []);
 
   useEffect(() => {
+    mountedRef.current = true;
     fetchRates();
+    return () => {
+      mountedRef.current = false;
+    };
   }, [fetchRates]);
 
   const convertToSats = useCallback(


### PR DESCRIPTION
## Summary

Ports two small robustness fixes from the sibling **robotechy-website** (shared codebase):

- **`useExchangeRate` unmount guard** (robotechy #80) — the async rate fetch could `setState` after the component unmounts, surfacing as an unhandled "window is not defined" from React's scheduler on test teardown. Now guarded by a `mountedRef`.
- **order-service relay classifier** (robotechy #61) — treat nostr-tools' `"publish timed out"` as ignorable relay noise so one slow relay that never ACKs a published event can't crash the order-service (this pattern crashed robotechy's production on 2026-07-02). Generic/HTTP timeouts stay fatal.

## Test plan

- `npm run test` — typecheck + ESLint + Vitest (105) + build all pass.
- order-service `npm test` — 24 pass, including a new case asserting `"publish timed out"` is ignored while `"Request Timeout"` / `"fetch timeout"` remain fatal.
- No UI change — no screenshot applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)